### PR TITLE
Regex Update + Replacement Bugfix

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,24 +19,32 @@ if (!Array.prototype.forEach) {
 }
 
 module.exports = function(text, htTemplate, unTemplate) {
-	// Escape HTML characters
-	text = htmlEscape(text);
+  // Escape HTML characters
+  text = htmlEscape(text);
 
-	// Hashtags
-	var hashtags = text.match(/[#]\w+/g);
-	if (hashtags) {
-		hashtags.forEach(function(ht) {
-			text = text.replace(ht, hashtag(ht, htTemplate));
-		});
-	};
+  // Usernames
+  text = text.replace(/(^|[\W])@\w(\w|\.)*/g, function(matched) {
+    var prefix = '';
+    var postfix = '';
+    var postfixIdx;
+    // Remove any leading non-word character
+    if (/^[\W]@/.test(matched)) {
+      prefix = matched.slice(0, 1);
+      matched = matched.slice(1);
+    }
+    // Remove any trailing periods
+    postfixIdx = matched.search(/\.+$/);
+    if (postfixIdx > -1) {
+      postfix = matched.slice(postfixIdx);
+      matched = matched.slice(0, postfixIdx);
+    }
+    return prefix + username(matched, unTemplate) + postfix;
+  });
 
-	// Usernames
-	var usernames = text.match(/[@]\w+/g);
-	if (usernames) {
-		usernames.forEach(function(un) {
-			text = text.replace(un, username(un, unTemplate));
-		});
-	}
+  // Hashtags
+  text = text.replace(/#(\w|[^\u0000-\u007F])+/g, function(matched) {
+    return hashtag(matched, htTemplate);
+  });
 
-	return text;
+  return text;
 };

--- a/src/test/index_test.js
+++ b/src/test/index_test.js
@@ -65,7 +65,7 @@ describe('linkify', function() {
 	});
 
 	it('should linkify captions with username blocks correctly', function() {
-		var expected = 'Hello <a href="https://www.instagram.com/world">@world</a><a href="https://www.instagram.com/sup">@sup</a> <a href="https://www.instagram.com/javascript">@javascript</a>';
+		var expected = 'Hello <a href="https://www.instagram.com/world">@world</a>@sup <a href="https://www.instagram.com/javascript">@javascript</a>';
 		var caption = 'Hello @world@sup @javascript';
 		linkify(caption).should.equal(expected);
 	});
@@ -76,4 +76,87 @@ describe('linkify', function() {
 		linkify(caption).should.equal(expected);
 	});
 	
+	it('should linkify a hashtag at the beginning of the string', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/hello">#hello</a> world!';
+		var caption = '#hello world!';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a username at the beginning of the string', function() {
+		var expected = '<a href="https://www.instagram.com/hello">@hello</a> world!';
+		var caption = '@hello world!';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify usernames prefixed with a non-letter, number, or underscore', function() {
+		var expected = '.<a href="https://www.instagram.com/hello">@hello</a> world! h@this 1@is _@a *<a href="https://www.instagram.com/test">@test</a>';
+		var caption = '.@hello world! h@this 1@is _@a *@test';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a username with trailing periods', function() {
+		var expected = '.<a href="https://www.instagram.com/hello">@hello</a>.. world!';
+		var caption = '.@hello.. world!';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a username with trailing non-letter, number, or underscore', function() {
+		var expected = '<a href="https://www.instagram.com/hello">@hello</a>* world!';
+		var caption = '@hello* world!';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a username with leading and trailing emojis', function() {
+		var expected = '😁<a href="https://www.instagram.com/hello">@hello</a>⚡️ world!';
+		var caption = '😁@hello⚡️ world!';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a hashtag, but not a username when in that order back-to-back', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/hello">#hello</a>@world';
+		var caption = '#hello@world';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a username and hashtag when in that order back-to-back', function() {
+		var expected = '<a href="https://www.instagram.com/hello">@hello</a><a href="https://www.instagram.com/explore/tags/world">#world</a>';
+		var caption = '@hello#world';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify an actual instagram example with hashtag overlap', function() {
+		var expected = 'Can you believe <a href="https://www.instagram.com/explore/tags/NashvilleJuly4">#NashvilleJuly4</a> is only 5 days away? That\'s 5 days until fireworks are launched from Nissan Stadium lighting up the sky. We can\'t wait! Double tap if you agree. <a href="https://www.instagram.com/explore/tags/Nashville">#Nashville</a> <a href="https://www.instagram.com/explore/tags/MusicCity">#MusicCity</a>';
+		var caption = 'Can you believe #NashvilleJuly4 is only 5 days away? That\'s 5 days until fireworks are launched from Nissan Stadium lighting up the sky. We can\'t wait! Double tap if you agree. #Nashville #MusicCity';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify back-to-back hashtags', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/hello">#hello</a><a href="https://www.instagram.com/explore/tags/world">#world</a>';
+		var caption = '#hello#world';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify emoji hashtags', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/🔥😎">#🔥😎</a> <a href="https://www.instagram.com/explore/tags/test⚡️emoji">#test⚡️emoji</a>';
+		var caption = '#🔥😎 #test⚡️emoji';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify unicode hashtags correctly', function() {
+		var expected = 'don\'t know what this says: <a href="https://www.instagram.com/explore/tags/絵文字">#絵文字</a>';
+		var caption = 'don\'t know what this says: #絵文字';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a hashtag with multiple hashes', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/keyboard">#keyboard</a> #<a href="https://www.instagram.com/explore/tags/cat">#cat</a>';
+		var caption = '#keyboard ##cat';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('shouldn\'t linkify a username starting with a period', function() {
+		var expected = 'keyboard @.cat.';
+		var caption = 'keyboard @.cat.';
+		linkify(caption).should.equal(expected);
+	});
 });

--- a/src/test/index_test.js
+++ b/src/test/index_test.js
@@ -159,4 +159,16 @@ describe('linkify', function() {
 		var caption = 'keyboard @.cat.';
 		linkify(caption).should.equal(expected);
 	});
+
+	it('should linkify a hashtag, but stop at a period character', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/keyboard">#keyboard</a>.cat';
+		var caption = '#keyboard.cat';
+		linkify(caption).should.equal(expected);
+	});
+
+	it('should linkify a hashtag containing an underscore', function() {
+		var expected = '<a href="https://www.instagram.com/explore/tags/keyboard_cat">#keyboard_cat</a>';
+		var caption = '#keyboard_cat';
+		linkify(caption).should.equal(expected);
+	});
 });


### PR DESCRIPTION
**Update Hashtag Regex**

The regex for hashtags has been updated to `/#(\w|[^\u0000-\u007F])+/g`.
Based on my tests using Instagram, a hashtag can contain any character excluding the range \u0000 - \u007F. Word characters within that range are obviously acceptable. This will therefore match emoji hashtags and hashtags using non-latin characters. As far as I can tell - this is accurate.

Examples:
- `#keyboard #cat` matches `(#keyboard + #cat)`
- `#keyboard ##cat` matches `(#keyboard + #cat)`
- `#⚡️😎` matches `(#⚡️😎)`
- `#test #絵文字` matches `(#test + #絵文字)`
- `#test_ing` matches `(#test_ing)`
- `#test.ing` matches `(#test)`

**Update Username Regex**

The regex for usernames has been updated to `/(^|[\W])@\w(\w|\.)*/g`.
Based on my tests using Instagram, the following are requirements for usernames within text:
- must either be the start of the text, or be prefixed with a non-word character, where a word character is any alphanumeric character or an underscore.
- usernames can contain any word character or period, but cannot start or end with a period.
- usernames can be terminated by any non-word character.

Because this regex can match usernames with a leading non-word character, or trailing periods, they must be removed before adding the `<a>` tag.

Examples:

`@valid` represents a valid username
`@invalid` represents an invalid username
- `.@valid test`
- `test @valid`
- `test @valid&something`
- `test @valid..`
- `⚡️@valid⚡️`
- `hi@invalid`
- `2@invalid`
- `_@invalid`
- `@valid@invalid`

**Fix For Multiple Hashtags/Usernames Bug**

Also part of this PR is a fix for when multiple hashtags/usernames exist and the first is prefixed with the following. Previously, the regex `match` function was used to find hashtags/usernames in the text. For each match, `replace` would be called with the new hashtag/username replacement. With this flow, if a hashtag (e.g. #TestHashtag) is followed by a hashtag that prefixes the original (e.g. #Test), the `replace` will replace the prefix on the first hashtag.

For a real-world example, the string `Can you believe #NashvilleJuly4 is only 5 days away? That\'s 5 days until fireworks are launched from Nissan Stadium lighting up the sky. We can\'t wait! Double tap if you agree. #Nashville #MusicCity` would be converted to:

``` html
Can you believe <a href="https://www.instagram.com/explore/tags/NashvilleJuly4"><a href="https://www.instagram.com/explore/tags/Nashville">#Nashville</a>July4</a> is only 5 days away? That's 5 days until fireworks are launched from Nissan Stadium lighting up the sky. We can't wait! Double tap if you agree. #Nashville <a href="https://www.instagram.com/explore/tags/MusicCity">#MusicCity</a>
```

The `#Nashville` at the end of the string would match and then replace the `#Nashville` in the `#NashvilleJuly4` hashtag.

This PR now uses the regex `replace` function directly to avoid this issue.
